### PR TITLE
Gracefully fail callback function if module not found

### DIFF
--- a/pellet/middleware.py
+++ b/pellet/middleware.py
@@ -94,7 +94,7 @@ class PelletMiddleware:
                     response=response,
                     pellet_metrics=pellet_metrics.__dict__,
                 )
-            except (AttributeError, IndexError):
+            except (AttributeError, IndexError, ModuleNotFoundError):
                 logger.exception(
                     "Pellet callback: {callback_name} failed".format(
                         callback_name=callback_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pellet"
-version = "0.1.2"
+version = "0.1.3"
 description = "Pellet helps improve your Django app performance by discovering N+1 queries"
 authors = ["Harikrishnan Shaji <hihari777@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Fix to make sure the entire request doesn't fail because the callback function module specified was incorrect.
