### PR TITLE
Allow rich>=12.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["django", "python", "performance", "database", "N+1"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-rich = "12.5.1"
+rich = ">=12.5.1"
 
 [tool.poetry.dev-dependencies]
 Django = "4.0.6"


### PR DESCRIPTION
Set rich 12.5.1 as minimum version rather than exact version. This will allow installs in environments where rich already is set at a recent version of rich.